### PR TITLE
Drill tool order relaxed

### DIFF
--- a/gerber_renderer/Gerber.py
+++ b/gerber_renderer/Gerber.py
@@ -467,11 +467,8 @@ class Board:
             diameter = tool['diameter']
             # draw all holes for current tool
             curr_holes = file.find(tool['name'])
+            next_tool = file.find('T', curr_holes+1)
 
-            if(tool['next'] != ''):
-                next_tool = file.find(tool['next'], curr_holes)
-            else:
-                next_tool = -1
             curr_x = file.find('X', curr_holes)
             curr_y = file.find('Y', curr_x)
 
@@ -562,7 +559,6 @@ class Board:
             c_index = file.find('C', index)
             curr_tool['name'] = file[index:c_index]
             next_index = file.find('T', c_index)
-            curr_tool['next'] = file[next_index:file.find('C', next_index)]
 
             # get diameter
             curr_tool['diameter'] = float(file[c_index+1:next_index])


### PR DESCRIPTION
Previous approach assumed that drill definitions and positions are in the same order. 
But Eagle exports positions in reverse order:
definitions: T7, T6, T5, T4, T3, T2, T1
positions: T1, T2, T3... T7
When e.g. T3 holes are handled, next from the definition order is T2. Since T2 positions are actually before T3 it is not found (-1), thus current code assumes it is the last one and includes all positions from that point forward (rendering T4-T7 positions with drill size of T3). It continues to T4 and renders T5-T7 positions with T4's size and so on. 
So large black circle ends up on every small via's hole.

Offending file drills_1_16.xln:
```
M48
;GenerationSoftware,Autodesk,EAGLE,9.6.2*%
;CreationDate,2021-11-19T14:46:49Z*%
FMAT,2
ICI,OFF
METRIC,TZ,000.000
T7C0.200
T6C0.350
T5C0.400
T4C0.500
T3C0.800
T2C1.321
T1C5.200
%
G90
M71
T1
X54500Y22225
T2
X69050Y28150
X73925Y28275
X65748Y8625
X15075Y3545
T3
X37825Y20300
X35825Y20300
X33825Y20300
X31825Y20300
T4
X21325Y8425
T5
X110725Y22975
X104725Y22975
X104725Y24975
T6
X26825Y21400
T7
X95950Y25425
X94825Y25425
X93650Y25425
X87750Y25425
M30
```